### PR TITLE
Replace all psql commands with docker exec ones

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@ CONTRIBUTORS
 ------------
 
 - [Diego Mesa](https://github.com/dialmedu)
+- [fgehrlicher](https://github.com/fgehrlicher)

--- a/SETUP.md
+++ b/SETUP.md
@@ -13,11 +13,11 @@ POSTGRES_PASSWORD=mysecretpassword docker-compose -f docker-compose.yml -f docke
 
 docker run -v $PWD/migrations:/migrations/ --network="container:schema_db_1" migrate/migrate -path=/migrations -database "postgresql://postgres:mysecretpassword@schema_db_1:5432/postgres?sslmode=disable" up # initialise database
 
-docker exec -i -e PGPASSWORD=mysecretpassword eventzimmer_schema-db psql --user postgres -h localhost -c "\copy eventzimmer.sources FROM /fixtures/sources.csv DELIMITER ',' CSV HEADER;" # insert sources
+docker exec -i -e PGPASSWORD=mysecretpassword schema_db_1 psql --user postgres -h localhost -c "\copy eventzimmer.sources FROM /fixtures/sources.csv DELIMITER ',' CSV HEADER;" # insert sources
 
-docker exec -i -e PGPASSWORD=mysecretpassword eventzimmer_schema-db psql --user postgres -h localhost -c "\copy eventzimmer.locations FROM fixtures/locations.csv DELIMITER ',' CSV HEADER;" # insert locations
+docker exec -i -e PGPASSWORD=mysecretpassword schema_db_1 psql --user postgres -h localhost -c "\copy eventzimmer.locations FROM fixtures/locations.csv DELIMITER ',' CSV HEADER;" # insert locations
 
-docker exec -i -e PGPASSWORD=mysecretpassword eventzimmer_schema-db bash -c "psql --user postgres -h localhost < /fixtures/events.sql" # insert events
+docker exec -i -e PGPASSWORD=mysecretpassword schema_db_1 bash -c "psql --user postgres -h localhost < /fixtures/events.sql" # insert events
 ```
 
 You may need to restart the services after initial setup. On consecutive starts you only fire up the `Docker` containers, as their volume persists [until deleted](https://docs.docker.com/compose/reference/down/).
@@ -31,7 +31,7 @@ POSTGRES_PASSWORD=mysecretpassword docker-compose -f docker-compose.yml -f docke
 If you need introspection into the `Postgres` instance you can use `docker exec`:
 
 ```
-docker exec -i -e PGPASSWORD=mysecretpassword eventzimmer_schema-db psql --user postgres -h localhost
+docker exec -i -e PGPASSWORD=mysecretpassword schema_db_1 psql --user postgres -h localhost
 ```
 
 ## Setting up authentication

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,7 +6,6 @@ To get a local setup you will need to have the following tools installed on your
 
 - [Docker](https://www.docker.com/)
 - [Docker Compose](https://docs.docker.com/compose/)
-- [psql](https://www.postgresql.org/docs/9.2/app-psql.html)
 
 Within this directory, follow the white rabbit:
 ```
@@ -14,11 +13,11 @@ POSTGRES_PASSWORD=mysecretpassword docker-compose -f docker-compose.yml -f docke
 
 docker run -v $PWD/migrations:/migrations/ --network="container:schema_db_1" migrate/migrate -path=/migrations -database "postgresql://postgres:mysecretpassword@schema_db_1:5432/postgres?sslmode=disable" up # initialise database
 
-PGPASSWORD=mysecretpassword psql --user postgres -h localhost -c "\copy eventzimmer.sources FROM fixtures/sources.csv DELIMITER ',' CSV HEADER;" # insert sources
+docker exec -i -e PGPASSWORD=mysecretpassword eventzimmer_schema-db psql --user postgres -h localhost -c "\copy eventzimmer.sources FROM /fixtures/sources.csv DELIMITER ',' CSV HEADER;" # insert sources
 
-PGPASSWORD=mysecretpassword psql --user postgres -h localhost -c "\copy eventzimmer.locations FROM fixtures/locations.csv DELIMITER ',' CSV HEADER;" # insert locations
+docker exec -i -e PGPASSWORD=mysecretpassword eventzimmer_schema-db psql --user postgres -h localhost -c "\copy eventzimmer.locations FROM fixtures/locations.csv DELIMITER ',' CSV HEADER;" # insert locations
 
-PGPASSWORD=mysecretpassword psql --user postgres -h localhost < fixtures/events.sql # insert events
+docker exec -i -e PGPASSWORD=mysecretpassword eventzimmer_schema-db bash -c "psql --user postgres -h localhost < /fixtures/events.sql" # insert events
 ```
 
 You may need to restart the services after initial setup. On consecutive starts you only fire up the `Docker` containers, as their volume persists [until deleted](https://docs.docker.com/compose/reference/down/).
@@ -29,10 +28,10 @@ To fire up the containers you must supply the `POSTGRES_PASSWORD` environment va
 POSTGRES_PASSWORD=mysecretpassword docker-compose -f docker-compose.yml -f docker-compose.dev.yml up # fire up docker
 ```
 
-If you need introspection into the `Postgres` instance you can use `psql`:
+If you need introspection into the `Postgres` instance you can use `docker exec`:
 
 ```
-PGPASSWORD=mysecretpassword psql --user postgres -h localhost
+docker exec -i -e PGPASSWORD=mysecretpassword eventzimmer_schema-db psql --user postgres -h localhost
 ```
 
 ## Setting up authentication

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,9 @@ services:
     db:
       ports:
       - "5432:5432"
+      volumes:
+        - ./fixtures:/fixtures
+      container_name: eventzimmer_schema-db
     api:
       ports:
       - "3000:3000"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,6 @@ services:
       - "5432:5432"
       volumes:
         - ./fixtures:/fixtures
-      container_name: eventzimmer_schema-db
     api:
       ports:
       - "3000:3000"


### PR DESCRIPTION
resolves #17
-
I replaced all psql occurrences with docker exec ones. I chose docker exec over docker run because the postgress image you are using already includes psql and it would add unnecessary complexity to spin up an additional container just to psql there.
I also extended the dev docker-compose file with an additional mount in order to avoid the need to copy the fixtures into the db container first (if the mount is a problem i could remove the mount and add docker cp commands).
