### PR TITLE
fix API base URL for prod

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,8 @@ services:
     api:
       ports:
       - "3000:3000"
+      environment:
+        PGRST_SERVER_PROXY_URI: "http://localhost:3000"
     docs:
       environment:
         URL: http://localhost:3000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   proxy:
-    image: traefik
+    image: traefik:1.7-alpine
     restart: always
     ports:
       - "80:80"
@@ -29,6 +29,8 @@ services:
     networks:
       - internal
       - web
+    environment:
+      PGRST_SERVER_PROXY_URI: "https://api.eventzimmer.de:443"
   docs:
     restart: always
     labels:


### PR DESCRIPTION
After understanding the issue the fix was fairly simple. :smile: 

The Swagger UI extracts the API base URL out of the API definition. So fixing #18 requires to set the correct host at the API server (postgrest).

Additionally I pinned the traefik version to 1.7 as the current configuration is not compatible with the new major version 2.0. Can take care of the migration in another PR if necessary.